### PR TITLE
feat: CQDG-688 Attach persistent volume to nextflow pod and use stabl…

### DIFF
--- a/qa-etl/apps/nextflow/kustomization.yaml
+++ b/qa-etl/apps/nextflow/kustomization.yaml
@@ -6,3 +6,4 @@ namespace: cqdg-qa
 resources:
   - configs.yml
   - nextflow.yml
+  - pvc.yml

--- a/qa-etl/apps/nextflow/nextflow.yml
+++ b/qa-etl/apps/nextflow/nextflow.yml
@@ -10,9 +10,12 @@ spec:
         - name: nextflow
           configMap:
             name: nextflow
+        - name: cqdg-qa-nextflow-data
+          persistentVolumeClaim:
+            claimName: cqdg-qa-nextflow-pvc
     containers:
     - name: nextflow
-      image: nextflow/nextflow:24.02.0-edge
+      image: nextflow/nextflow:23.10.1
       env:
         - name: NXF_WORK
           value: s3://cqdg-qa-file-import/nextflow/scratch
@@ -33,3 +36,6 @@ spec:
       volumeMounts:
         - name: nextflow
           mountPath: /root/nextflow/config
+        - name: cqdg-qa-nextflow-data
+          mountPath: /mnt/workspace
+          subPath: cqdg-qa/nextflow/workspace

--- a/qa-etl/apps/nextflow/pvc.yml
+++ b/qa-etl/apps/nextflow/pvc.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cqdg-qa-nextflow-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: csi-cephfs-sc
+  selector:
+    matchLabels:
+      environment: nextflow-qa


### PR DESCRIPTION
We attach the persistent volume on the nextflow pod, as done recently in the production environment. 

We also change the nextflow version (24.02.0-edge) to a more stable version (23.10.1), as done in the production environment as well.

**Links**

JIRA ticket asscioated with the present pull request:
https://ferlab-crsj.atlassian.net/browse/CQDG-688

JIRA and pull request links for the creation of the nextflow pod in the production environment:
https://ferlab-crsj.atlassian.net/browse/CQDG-682
https://github.com/Ferlab-Ste-Justine-Ops/cqdg-prod-kubernetes-environments/pull/85

**Test procedure**

I tested locally with Minikube with a fake persistent volume.  The persistent volume claim and the pods are correctly created. The persistent volume is mounted on the pod and I can see that the docker image used is matching 23.10.1, as expected.

I used the manifest files generated with kustomize commands to create the resources in the test cluster. Ex:
```
kustomize build nextflow-access >build_nextflow_access.yaml
kustomize build nextflow >build_nextflow.yaml

kubectl create -f build_nextflow_access.yaml
kubectl create -f build_nextflow.yaml
```
